### PR TITLE
Load settings from different path

### DIFF
--- a/logindialog.cpp
+++ b/logindialog.cpp
@@ -7,9 +7,10 @@
 #include <QtGui>
 #include <QMessageBox>
 
-LoginDialog::LoginDialog(QWidget *parent,bool canautologin) : LoginDialogBase(parent)
+LoginDialog::LoginDialog(QWidget *parent,bool canautologin, QString *settingsFilename) : LoginDialogBase(parent)
 {
-	PMSettings *pmsettings = new PMSettings();
+	this->settingsFilename = *settingsFilename;
+	PMSettings *pmsettings = new PMSettings(this->settingsFilename);
 
 	ui.PasswordEdit->setText(pmsettings->getAttributeSettings("password"));
 	ui.HostEdit->setText(pmsettings->getAttributeSettings("host"));
@@ -45,7 +46,7 @@ void LoginDialog::on_cancelButton_clicked()
 
 void LoginDialog::canContinue()
 {
-        PMSettings *pmsettings = new PMSettings();
+		PMSettings *pmsettings = new PMSettings(settingsFilename);
         if (pmsettings->getAttributeSettings("autologin") == "true")
         {
             LhcWebServiceClient *lhwsc = LhcWebServiceClient::instance();
@@ -125,7 +126,7 @@ void LoginDialog::on_okButton_clicked()
 
                 if (!host.isEmpty())
 				{
-                        PMSettings *pmsettings = new PMSettings();
+						PMSettings *pmsettings = new PMSettings(settingsFilename);
 
                         if (ui.RememberLoginsChk->isChecked()){
                             pmsettings->setAttribute("username",lgUserName);

--- a/logindialog.h
+++ b/logindialog.h
@@ -9,7 +9,7 @@ class LoginDialog : public LoginDialogBase
 	Q_OBJECT
 		
 	public:
-		LoginDialog(QWidget *parent = 0,bool canautologin = false);
+		LoginDialog(QWidget *parent = 0,bool canautologin = false, QString *settingsFilename = NULL);
 		~LoginDialog();
 
     static void LoginCheckedCallback(void* pt2Object, QByteArray result);
@@ -23,7 +23,8 @@ class LoginDialog : public LoginDialogBase
 	private:
     QString lgUserName,       ///< Vartotojo tapatybës vardas. 
             lgUserPassword,   ///< Vartotojo tapatybës slaptaþodis.
-            lgHost;           ///< Serverio adresas.
+			lgHost,           ///< Serverio adresas.
+			settingsFilename;
 
            
 };

--- a/main.cpp
+++ b/main.cpp
@@ -22,8 +22,12 @@ styleFile.open( QFile::ReadOnly );
 QString style( styleFile.readAll() );
 app.setStyleSheet( style );
 
-
-
+// Load settings from different location
+QString settingsFilename = qApp->applicationDirPath() + "/settings.xml";
+if(argc > 1)
+{
+    settingsFilename = QString::fromUtf8(argv[1]);
+}
 
 qApp->addLibraryPath( qApp->applicationDirPath() + "/plugins");
 
@@ -31,7 +35,7 @@ qApp->addLibraryPath( qApp->applicationDirPath() + "/plugins");
 
 QTranslator translator;
 
-PMSettings *pmsettings = new PMSettings();
+PMSettings *pmsettings = new PMSettings(settingsFilename);
 translator.load("translations/lhc_"+pmsettings->getAttributeSettings("language")+".qm");
 delete pmsettings;
 
@@ -42,7 +46,7 @@ QCoreApplication::setOrganizationName("Remdex");
 QCoreApplication::setOrganizationDomain("remdex.info");
 QCoreApplication::setApplicationName("Live helper chat");
 
-LoginDialog *lgnDialog = new LoginDialog(0,true);
+LoginDialog *lgnDialog = new LoginDialog(0,true,&settingsFilename);
 
 if(!lgnDialog->exec())
 {
@@ -52,8 +56,8 @@ if(!lgnDialog->exec())
 delete lgnDialog;
 
 
-MainWindow w;
-w.show();
+MainWindow *w = new MainWindow(settingsFilename);
+w->show();
 app.connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
 	return app.exec();
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -17,10 +17,11 @@
 /**
 *Class constructor
 **/
-MainWindow::MainWindow()
+MainWindow::MainWindow(QString &settingsFilename)
 {
     //QApplication::setStyle(QStyleFactory::create("cleanlooks"));
 
+    this->settingsFilename = settingsFilename;
 	mdiArea = new QMdiArea;
     setCentralWidget(mdiArea);
 
@@ -65,7 +66,7 @@ MainWindow::MainWindow()
     connect(mouseTimer, SIGNAL(timeout()), this, SLOT(mouseTimerTick()));
 
 
-    PMSettings *pmsettings = new PMSettings();
+    PMSettings *pmsettings = new PMSettings(settingsFilename);
     offlineTimeout = pmsettings->getAttributeSettings("offlinetimeout").toInt();
     onlineofflineAutoAct->setChecked(pmsettings->getAttributeSettings("autooffline").toInt() == 1);
     if (onlineofflineAutoAct->isChecked()){
@@ -290,7 +291,7 @@ void MainWindow::chatOnlineStatus()
 
 void MainWindow::chatOnlineAutoStatus()
 {
-    PMSettings *pmsettings = new PMSettings();
+    PMSettings *pmsettings = new PMSettings(settingsFilename);
     if (this->onlineofflineAutoAct->isChecked()) {
         pmsettings->setAttribute("autooffline","1");
         mouseTimer->start(1000);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -23,7 +23,7 @@ class MainWindow : public QMainWindow
 {
     Q_OBJECT
 public:
-    MainWindow();
+    MainWindow(QString &settingsFilename);
     static void parseOnlineStatus(void* pt2Object, QByteArray result);
 
     /**
@@ -74,7 +74,7 @@ private slots:
     
 private:
 
-
+    QString settingsFilename;
     QPoint mouseLastPos;
     QTimer *mouseTimer;
     quint32 mouseIdleSeconds;

--- a/pmsettings.cpp
+++ b/pmsettings.cpp
@@ -7,11 +7,11 @@
 
 #include "pmsettings.h"
 
-const QString PMSettings::filename = "settings.xml";
 
-PMSettings::PMSettings()
+PMSettings::PMSettings(QString &settingsFilename)
 {
 	doc = new QDomDocument;
+	this->settingsFilename = settingsFilename;
 	LoadSettings();
 };
 
@@ -22,7 +22,7 @@ PMSettings::~PMSettings()
 
 void PMSettings::LoadSettings( )
 {		
-	 QFile file(qApp->applicationDirPath()+"/"+PMSettings::filename);
+	 QFile file(this->settingsFilename);
 	 if (!file.open(QIODevice::ReadOnly))
 	 {
 		 	qDebug("cannot load settings file");
@@ -33,7 +33,7 @@ void PMSettings::LoadSettings( )
 	 {
 		 qDebug(file.readAll().toBase64());
 		 QMessageBox::warning(NULL, "Warning",
-                             PMSettings::filename,
+                             this->settingsFilename,
                              "&OK", QString::null , 0, 0, 1);
 
 		 file.close();
@@ -49,7 +49,7 @@ bool PMSettings::sync()
 	//qDebug("Document source new - %s",doc->toString().toStdString().c_str());
 
 
-	QFile fileOut(qApp->applicationDirPath()+"/"+PMSettings::filename);
+    QFile fileOut(this->settingsFilename);
     if (!fileOut.open(QIODevice::WriteOnly)) 
     {
 		return false;

--- a/pmsettings.h
+++ b/pmsettings.h
@@ -35,7 +35,7 @@ public:
     *
     * @author Remigijus Kiminas
     **/ 
-    PMSettings();
+    PMSettings(QString &settingsFilename);
 
 	/**
     * @brief Klasës konstruktorius.
@@ -54,7 +54,7 @@ public:
 private:
 
 	
-	static const QString filename; ///< Failas i kuri saugoma
+    QString settingsFilename; ///< Failas i kuri saugoma
 
 	
 


### PR DESCRIPTION
Allow passing settings.xml as an argument so it does not have to be placed in the same dir as the binary. We needed this for roaming profiles under Win, so we can install the chat in the program directory and the settings in the profile.
